### PR TITLE
Fix typo HLSL asin() range from '?' to pi 'π'

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-asin.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-asin.md
@@ -46,7 +46,7 @@ The arcsine of the *x* parameter.
 
 ## Remarks
 
-Each component of the *x* parameter should be within the range of -?/2 to ?/2.
+Each component of the *x* parameter should be within the range of -π/2 to π/2.
 
 ## Type Description
 


### PR DESCRIPTION
Looks like the pi became mojibake.